### PR TITLE
fix: amending .csv outputs from interact.py

### DIFF
--- a/notebooks/anu_winter_2024/anu_pD6_workflow_demo.ipynb
+++ b/notebooks/anu_winter_2024/anu_pD6_workflow_demo.ipynb
@@ -62,7 +62,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pD6_raw_data = import_run_data(path_to_pD6_data, input_type=\"raw spectra\", output_folder = '/Users/anuram/Documents/240808_test4')\n",
+    "pD6_raw_data = import_run_data(path_to_pD6_data, input_type=\"raw spectra\", output_folder = '../../output_plots/')\n",
     "wv_data = import_run_data(path_to_water_vapor_data)"
    ]
   },
@@ -181,7 +181,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,

--- a/src/hydrogenase_processing/interact.py
+++ b/src/hydrogenase_processing/interact.py
@@ -144,14 +144,14 @@ def interact(prospecpy_objects, threshold_guess, adj_guess):
             rows = zip(anchor_point_wv_save, anchor_point_ab_save)
             
             #export the samples in their individual csv file
-            file_path = f'{prospecpy_objects[0].output_folder}/{sample_name}_anchor_point_coordinates.csv'
+            file_path = f'{prospecpy_obj.output_folder}/anchor_point_coordinates.csv'
 
             with open(file_path, mode='w', newline='') as file:
                 #create a csv writer object
                 writer = csv.writer(file)
                 
                 #write the headers
-                headers = ["Wavenumber", "Asborbance", f"{sample_name}"]
+                headers = ["Wavenumber", "Asborbance"]
                 writer.writerow(headers)
 
                 #wirte the data


### PR DESCRIPTION
Making sure that files write to folders to each individual sample, rather than all going into the first one. Additionally, removing blank column in anchor points .csv output.